### PR TITLE
fix: adaptando variables de verify-email al account-setup

### DIFF
--- a/src/app/modules/auth/pages/account-setup/pages/account-setup.component.ts
+++ b/src/app/modules/auth/pages/account-setup/pages/account-setup.component.ts
@@ -169,12 +169,7 @@ export class AccountSetupComponent implements OnInit {
             next: response => {
               this.successOperation = true;
               this.showModal = true;
-              this.router.navigate(['/confirmation'], {
-                queryParams: {
-                  nameUser: this.registerForm.value.first_name,
-                  type: 'mail',
-                },
-              });
+              this.router.navigate(['/candidato']);
             },
             error: error => {
               this.successOperation = false;

--- a/src/app/modules/auth/pages/verify-email/verify-email.component.ts
+++ b/src/app/modules/auth/pages/verify-email/verify-email.component.ts
@@ -37,9 +37,9 @@ export class VerifyEmailComponent implements OnInit {
           if (res.emailConfirmed === true) {
             const id = res.id;
             const email = res.email;
-            const name = res.first_name || res.name || '';
+            const first_name = res.first_name || res.name || '';
             this.router.navigate(['/account-setup'], {
-              queryParams: { email, name, id },
+              queryParams: { email, first_name, id },
             });
           } else {
             this.errorMessage = 'El email no ha sido confirmado aún.';


### PR DESCRIPTION
Cambios:

1. Se adaptó el parámetro name por first_name que se envía desde verify-email a account-setup

2. Se cambió la redirección de account-setup de una inexistente (/confirmation) a /canditato