### PR TITLE
Feature/modals verify email

### DIFF
--- a/src/app/modules/auth/pages/verify-email/verify-email.component.html
+++ b/src/app/modules/auth/pages/verify-email/verify-email.component.html
@@ -1,2 +1,76 @@
-<div>Loading: {{ loading }}</div>
-<div>Error: {{ errorMessage }}</div>
+<!-- Loader -->
+<div *ngIf="loading">
+  <p>Verificando tu correo...</p>
+</div>
+
+<!-- Modal: Token expirado -->
+<app-info-modal
+  *ngIf="showModal && currentModal === 'expired'"
+  (closed)="closeModal()">
+  <div modal-header>
+    <h3>Enlace expirado</h3>
+  </div>
+  <div modal-footer>
+    <div modal-image>
+      <img src="assets/images/sign-up/icon-bad-request-answer.png" alt="" />
+    </div>
+    <h3>El enlace de verificación ha expirado o es inválido.</h3>
+    <button class="btn btn-primary btn-form" (click)="closeModal()">
+      Volver a registrar
+    </button>
+  </div>
+</app-info-modal>
+
+<!-- Modal: Token inválido -->
+<app-info-modal
+  *ngIf="showModal && currentModal === 'invalid'"
+  (closed)="closeModal()">
+  <div modal-header>
+    <h3>Token inválido</h3>
+  </div>
+  <div modal-footer>
+    <div modal-image>
+      <img src="assets/images/sign-up/icon-request-alert.png" alt="" />
+    </div>
+    <h3>No se proporcionó un token válido.</h3>
+    <button class="btn btn-primary btn-form" (click)="closeModal()">
+      Intentar de nuevo
+    </button>
+  </div>
+</app-info-modal>
+
+<!-- Modal: Email no confirmado -->
+<app-info-modal
+  *ngIf="showModal && currentModal === 'notConfirmed'"
+  (closed)="closeModal()">
+  <div modal-header>
+    <h3>Email no confirmado</h3>
+  </div>
+  <div modal-footer>
+    <div modal-image>
+      <img src="assets/images/sign-up/icon-request-alert.png" alt="" />
+    </div>
+    <h3>Tu correo aún no ha sido confirmado. Revisa tu bandeja.</h3>
+    <button class="btn btn-primary btn-form" (click)="closeModal()">
+      Entendido
+    </button>
+  </div>
+</app-info-modal>
+
+<!-- Modal: Error inesperado -->
+<app-info-modal
+  *ngIf="showModal && currentModal === 'error'"
+  (closed)="closeModal()">
+  <div modal-header>
+    <h3>Upss. Ocurrió un problema</h3>
+  </div>
+  <div modal-footer>
+    <div modal-image>
+      <img src="assets/images/sign-up/icon-bad-request-answer.png" alt="" />
+    </div>
+    <h3>Error inesperado al verificar el token.</h3>
+    <button class="btn btn-primary btn-form" (click)="closeModal()">
+      Intentar de nuevo
+    </button>
+  </div>
+</app-info-modal>

--- a/src/app/modules/auth/pages/verify-email/verify-email.component.html
+++ b/src/app/modules/auth/pages/verify-email/verify-email.component.html
@@ -1,27 +1,6 @@
-<!-- Loader -->
-<div *ngIf="loading">
-  <p>Verificando tu correo...</p>
-</div>
+<!-- Loading -->
+<div *ngIf="loading">Verificando correo...</div>
 
-<!-- Modal: Token expirado -->
-<app-info-modal
-  *ngIf="showModal && currentModal === 'expired'"
-  (closed)="closeModal()">
-  <div modal-header>
-    <h3>Enlace expirado</h3>
-  </div>
-  <div modal-footer>
-    <div modal-image>
-      <img src="assets/images/sign-up/icon-bad-request-answer.png" alt="" />
-    </div>
-    <h3>El enlace de verificación ha expirado o es inválido.</h3>
-    <button class="btn btn-primary btn-form" (click)="closeModal()">
-      Volver a registrar
-    </button>
-  </div>
-</app-info-modal>
-
-<!-- Modal: Token inválido -->
 <app-info-modal
   *ngIf="showModal && currentModal === 'invalid'"
   (closed)="closeModal()">
@@ -30,45 +9,43 @@
   </div>
   <div modal-footer>
     <div modal-image>
-      <img src="assets/images/sign-up/icon-request-alert.png" alt="" />
-    </div>
-    <h3>No se proporcionó un token válido.</h3>
-    <button class="btn btn-primary btn-form" (click)="closeModal()">
-      Intentar de nuevo
-    </button>
-  </div>
-</app-info-modal>
-
-<!-- Modal: Email no confirmado -->
-<app-info-modal
-  *ngIf="showModal && currentModal === 'notConfirmed'"
-  (closed)="closeModal()">
-  <div modal-header>
-    <h3>Email no confirmado</h3>
-  </div>
-  <div modal-footer>
-    <div modal-image>
-      <img src="assets/images/sign-up/icon-request-alert.png" alt="" />
-    </div>
-    <h3>Tu correo aún no ha sido confirmado. Revisa tu bandeja.</h3>
-    <button class="btn btn-primary btn-form" (click)="closeModal()">
-      Entendido
-    </button>
-  </div>
-</app-info-modal>
-
-<!-- Modal: Error inesperado -->
-<app-info-modal
-  *ngIf="showModal && currentModal === 'error'"
-  (closed)="closeModal()">
-  <div modal-header>
-    <h3>Upss. Ocurrió un problema</h3>
-  </div>
-  <div modal-footer>
-    <div modal-image>
       <img src="assets/images/sign-up/icon-bad-request-answer.png" alt="" />
     </div>
-    <h3>Error inesperado al verificar el token.</h3>
+    <h3>{{ modalMessageBody }}</h3>
+    <button class="btn btn-primary btn-form" (click)="navigateToRegister()">
+      Ir al registro
+    </button>
+  </div>
+</app-info-modal>
+
+<app-info-modal
+  *ngIf="showModal && currentModal === 'expired'"
+  (closed)="closeModal()">
+  <div modal-header>
+    <h3>Token expirado</h3>
+  </div>
+  <div modal-footer>
+    <div modal-image>
+      <img src="assets/images/sign-up/icon-request-alert.png" alt="" />
+    </div>
+    <h3>{{ modalMessageBody }}</h3>
+    <button class="btn btn-primary btn-form" (click)="navigateToRegister()">
+      Obtener nuevo enlace
+    </button>
+  </div>
+</app-info-modal>
+
+<app-info-modal
+  *ngIf="showModal && currentModal === 'unexpected'"
+  (closed)="closeModal()">
+  <div modal-header>
+    <h3>Upss. Algo salió mal</h3>
+  </div>
+  <div modal-footer>
+    <div modal-image>
+      <img src="assets/images/sign-up/icon-request-answer.png" alt="" />
+    </div>
+    <h3>{{ modalMessageBody }}</h3>
     <button class="btn btn-primary btn-form" (click)="closeModal()">
       Intentar de nuevo
     </button>

--- a/src/app/modules/auth/pages/verify-email/verify-email.component.ts
+++ b/src/app/modules/auth/pages/verify-email/verify-email.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { HttpClient } from '@angular/common/http';
 import { UserService } from '../user.service';
 
 @Component({
@@ -9,13 +10,14 @@ import { UserService } from '../user.service';
 })
 export class VerifyEmailComponent implements OnInit {
   loading = true;
-
   showModal = false;
-  currentModal: 'expired' | 'invalid' | 'notConfirmed' | 'error' | null = null;
+  currentModal: 'expired' | 'invalid' | 'unexpected' | null = null;
+  modalMessageBody = '';
 
   constructor(
     private route: ActivatedRoute,
     private router: Router,
+    private http: HttpClient,
     private userService: UserService
   ) {}
 
@@ -23,15 +25,18 @@ export class VerifyEmailComponent implements OnInit {
     this.route.queryParams.subscribe(params => {
       const token = params['token'];
       if (!token) {
-        this.showModal = true;
         this.currentModal = 'invalid';
+        this.modalMessageBody = 'Token no proporcionado.';
+        this.showModal = true;
         this.loading = false;
         return;
       }
 
+      // Confirmar el email con el token
       this.userService.VerifyEmail(token).subscribe({
         next: (res: any) => {
           this.loading = false;
+
           if (res.emailConfirmed === true) {
             const id = res.user_id;
             const email = res.email;
@@ -40,19 +45,21 @@ export class VerifyEmailComponent implements OnInit {
               queryParams: { email, name, id },
             });
           } else {
+            this.currentModal = 'unexpected';
+            this.modalMessageBody = 'El email no ha sido confirmado aún.';
             this.showModal = true;
-            this.currentModal = 'notConfirmed';
           }
         },
         error: error => {
           this.loading = false;
           if (error.status === 400) {
-            this.showModal = true;
             this.currentModal = 'expired';
+            this.modalMessageBody = 'El enlace ha expirado o es inválido.';
           } else {
-            this.showModal = true;
-            this.currentModal = 'error';
+            this.currentModal = 'unexpected';
+            this.modalMessageBody = 'Error inesperado al verificar el token.';
           }
+          this.showModal = true;
         },
       });
     });
@@ -61,6 +68,9 @@ export class VerifyEmailComponent implements OnInit {
   closeModal() {
     this.showModal = false;
     this.currentModal = null;
-    this.router.navigate(['/register']); // o donde quieras que vaya si falla
+  }
+
+  navigateToRegister() {
+    this.router.navigate(['/register']);
   }
 }

--- a/src/app/modules/auth/pages/verify-email/verify-email.component.ts
+++ b/src/app/modules/auth/pages/verify-email/verify-email.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { HttpClient } from '@angular/common/http';
 import { UserService } from '../user.service';
 
 @Component({
@@ -10,50 +9,58 @@ import { UserService } from '../user.service';
 })
 export class VerifyEmailComponent implements OnInit {
   loading = true;
-  errorMessage = '';
+
+  showModal = false;
+  currentModal: 'expired' | 'invalid' | 'notConfirmed' | 'error' | null = null;
 
   constructor(
     private route: ActivatedRoute,
     private router: Router,
-    private http: HttpClient,
     private userService: UserService
   ) {}
 
   ngOnInit(): void {
-    console.log('VerifyEmailComponent ngOnInit');
     this.route.queryParams.subscribe(params => {
       const token = params['token'];
       if (!token) {
-        this.errorMessage = 'Token no proporcionado';
+        this.showModal = true;
+        this.currentModal = 'invalid';
         this.loading = false;
         return;
       }
 
-      // Confirmar el email con el token
       this.userService.VerifyEmail(token).subscribe({
         next: (res: any) => {
           this.loading = false;
-          // Validamos que el email esté confirmado
           if (res.emailConfirmed === true) {
-            const id = res.id;
+            const id = res.user_id;
             const email = res.email;
-            const name = res.first_name || res.name || '';
+            const name = res.name || '';
             this.router.navigate(['/account-setup'], {
               queryParams: { email, name, id },
             });
           } else {
-            this.errorMessage = 'El email no ha sido confirmado aún.';
+            this.showModal = true;
+            this.currentModal = 'notConfirmed';
           }
         },
         error: error => {
           this.loading = false;
           if (error.status === 400) {
-            this.errorMessage = 'El enlace ha expirado o es inválido.';
+            this.showModal = true;
+            this.currentModal = 'expired';
           } else {
-            this.errorMessage = 'Error inesperado al verificar el token.';
+            this.showModal = true;
+            this.currentModal = 'error';
           }
         },
       });
     });
+  }
+
+  closeModal() {
+    this.showModal = false;
+    this.currentModal = null;
+    this.router.navigate(['/register']); // o donde quieras que vaya si falla
   }
 }


### PR DESCRIPTION
Se actualizó VerifyEmailComponent para manejar errores mediante modales en lugar de mensajes de texto.

- Nuevos estados: invalid, expired, notConfirmed y error.

- Redirección automática a /account-setup si el correo se confirma.

- En caso de error, se muestra el modal correspondiente y luego se redirige a /register.