### PR TITLE
Feature/122 habilitar cards dashboard candidato

### DIFF
--- a/src/app/modules/all/pages/all-page/all-page.component.ts
+++ b/src/app/modules/all/pages/all-page/all-page.component.ts
@@ -7,6 +7,7 @@ import {
   EventEmitter,
 } from '@angular/core';
 import { Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import {
   trigger,
   style,
@@ -75,19 +76,31 @@ export class AllPageComponent implements OnInit {
 
   private allPageService = inject(AllPageService);
   constructor(
-    private router: Router,
-    private alertService: AlertService
+    private alertService: AlertService,
+    private route: ActivatedRoute
   ) {}
 
   ngOnInit(): void {
-    this.allPageService.getAllQuiz().subscribe((response: any) => {
-      if (!this.isAdmin) {
-        // Si el usuario no es admin, filtra solo los quizzes activos
-        this.quizzes = response.quizzes.filter((quiz: Quiz) => quiz.is_active);
-      } else {
-        // Si es admin, muestra todos los quizzes
-        this.quizzes = response.quizzes;
-      }
+    // this.allPageService.getAllQuiz().subscribe((response: any) => {
+    //   if (!this.isAdmin) {
+    //     // Si el usuario no es admin, filtra solo los quizzes activos
+    //     this.quizzes = response.quizzes.filter((quiz: Quiz) => quiz.is_active);
+    //   } else {
+    //     // Si es admin, muestra todos los quizzes
+    //     this.quizzes = response.quizzes;
+    //   }
+    // });
+
+   // 1. Suscribirse a los parámetros de la URL.
+    this.route.queryParams.subscribe(params => {
+      // 2. Asignar los valores de los parámetros a las propiedades del componente.
+      this.module = params['module'] || '';
+      this.cell = params['cell'] || '';
+      this.seniority = params['seniority'] || '';
+      this.searchText = params['search'] || '';
+
+      // 3. Llamar al método de filtrado que ahora será el único encargado de cargar los quizzes.
+      this.onSearchChange();
     });
   }
 

--- a/src/app/modules/candidato-dashboard/dashboard-cards/dashboard-cards.component.html
+++ b/src/app/modules/candidato-dashboard/dashboard-cards/dashboard-cards.component.html
@@ -11,5 +11,8 @@
         <img [src]="item.icon" [alt]="item.title" />
       </div>
     </div>
+    <div class="d-flex justify-content-end">
+      <button class="btn-all">→ Ver todos</button>
+    </div>
   </div>
 </section>

--- a/src/app/modules/candidato-dashboard/dashboard-cards/dashboard-cards.component.html
+++ b/src/app/modules/candidato-dashboard/dashboard-cards/dashboard-cards.component.html
@@ -6,13 +6,13 @@
   <div class="content">
     <h1>Selecciona tu stack</h1>
     <div class="grid">
-      <div class="card" *ngFor="let item of items">
+      <div class="card" *ngFor="let item of items" (click)="filtrarQuizzes(item.search)">
         <span class="title">{{ item.title }}</span>
         <img [src]="item.icon" [alt]="item.title" />
       </div>
     </div>
     <div class="d-flex justify-content-end">
-      <button class="btn-all">→ Ver todos</button>
+      <button class="btn-all" (click)="filtrarQuizzes('all')">→ Ver todos</button>
     </div>
   </div>
 </section>

--- a/src/app/modules/candidato-dashboard/dashboard-cards/dashboard-cards.component.scss
+++ b/src/app/modules/candidato-dashboard/dashboard-cards/dashboard-cards.component.scss
@@ -59,6 +59,7 @@
   background-color: #212121;
   box-shadow: 0px 4px 12px 0px rgba(0, 0, 0, 0.25);
   box-shadow: 0px 4px 9.5px 0px rgba(0, 0, 0, 0.25);
+  cursor: pointer;
 }
 
 .card:hover {

--- a/src/app/modules/candidato-dashboard/dashboard-cards/dashboard-cards.component.scss
+++ b/src/app/modules/candidato-dashboard/dashboard-cards/dashboard-cards.component.scss
@@ -1,4 +1,4 @@
-.subpage{
+.subpage {
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -29,6 +29,10 @@
   color: #ccc;
 }
 
+.content{
+  width: 100%;
+}
+
 .content h1 {
   text-align: center;
   margin-bottom: 3rem;
@@ -36,6 +40,7 @@
 }
 
 .grid {
+  padding: 0 20%;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   row-gap: 10px;
@@ -90,4 +95,29 @@
   opacity: 1;
   visibility: visible;
   transform: translateY(0);
+}
+
+.btn-all {
+  background: linear-gradient(
+    255.96deg,
+    rgba(106, 95, 255, 0.5) 0%,
+    rgba(255, 94, 166, 0.5) 100%
+  );
+  box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
+  width: 147;
+  height: 56;
+  opacity: 1;
+  gap: 8px;
+  padding: 16px;
+  border-radius: 8px;
+  border: none;
+  font-family: Poppins;
+  font-weight: 500;
+  font-style: Medium;
+  font-size: 14px;
+  line-height: 20px;
+  letter-spacing: 0.1px;
+  vertical-align: middle;
+  margin-bottom: 20px;
+  margin-right: 20px;
 }

--- a/src/app/modules/candidato-dashboard/dashboard-cards/dashboard-cards.component.ts
+++ b/src/app/modules/candidato-dashboard/dashboard-cards/dashboard-cards.component.ts
@@ -2,6 +2,8 @@ import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { User, AuthService } from '@auth0/auth0-angular';
 import { Observable } from 'rxjs';
+import { Router } from '@angular/router';
+import { query } from '@angular/animations';
 
 @Component({
   selector: 'app-dashboard-cards',
@@ -14,14 +16,42 @@ export class DashboardCardsComponent {
   user$: Observable<User | null> = this.auth.user$;
   userName: string = 'Usuario'; // Puedes obtener el nombre de usuario desde algún servicio
   currentDate: Date = new Date(); // Fecha actual
-  constructor(private auth: AuthService) {}
+  constructor(
+    private auth: AuthService,
+    private router: Router
+  ) {}
 
   items: any[] = [
-    { title: 'Diseño UX', icon: 'assets/ui.png' },
-    { title: 'Frontend', icon: 'assets/frontend.png' },
-    { title: 'Backend', icon: 'assets/backend.png' },
-    { title: 'Fullstack', icon: 'assets/fullstack.png' },
-    { title: 'PM', icon: 'assets/qa.png' },
-    { title: 'QA', icon: 'assets/scrum.png' },
+    // La propiedad search es el string que se usará para filtrar los quizzes al hacer click en el card
+    { title: 'Diseño UX', icon: 'assets/ui.png', search: 'UX/UI' },
+    {
+      title: 'Frontend',
+      icon: 'assets/frontend.png',
+      search: 'Frontend Developer',
+    },
+    {
+      title: 'Backend',
+      icon: 'assets/backend.png',
+      search: 'Backend Developer',
+    },
+    {
+      title: 'Fullstack',
+      icon: 'assets/fullstack.png',
+      search: 'Fullstack Development',
+    },
+    { title: 'PM', icon: 'assets/qa.png', search: 'P.M.' },
+    { title: 'QA', icon: 'assets/scrum.png', search: 'Q.A.' },
   ];
+
+  filtrarQuizzes(filter): void {
+    if (filter === 'all') {
+      //Si el filtro es all, muestra todos los quizzes
+      this.router.navigate(['/dashboard/quizzes']);
+    } else {
+      //De lo contrario, establece el filtro correspondiente
+      this.router.navigate(['dashboard/quizzes/'], {
+        queryParams: { cell: filter },
+      });
+    }
+  }
 }


### PR DESCRIPTION
Ticket #122 

- Se habilitó la funcionalidad de buscar quizzes por filtrado de las células directamente desde las cards del dashboard. 
- También se habilitó el botón "Ver todos" como atajo a ver todos los quizzes sin filtro.


NOTA: Los filtros de las cards atienden a strings específicos. Si los admin eliminan las células correspondientes, el filtrado dejará de funcionar. Queda pendiente establecer si las cards se cargarán dinámicamente desde las células registradas en la BD o de alguna otra manera.

