### PR TITLE
feat: boton de colapsar sidebar con flechas y texto.

### DIFF
--- a/src/app/shared/components/sideBar/side-bar/side-bar.component.html
+++ b/src/app/shared/components/sideBar/side-bar/side-bar.component.html
@@ -1,15 +1,26 @@
 <div [ngClass]="extended ? 'sidebar-container-extended' : 'sidebar-container'">
-  
-  <!-- Contenido del Sidebar -->
-  <div class="d-flex flex-column">
-    <button class="toggle-sidebar border-0 mb-3" (click)="toggleSidebar()">
-      <i class="bi bi-list"></i>
+
+    <!-- Boton para colapsar el sidebar. -->
+    <button
+        [ngClass]="extended ? 'sidebar-btns-extended' : 'sidebar-btns'"
+        class="active-btn mb-2"
+        (click)="toggleSidebar()"
+    >
+        <i
+            style="color:#2596be"
+            [ngClass]="extended ? 'bi bi-chevron-left' : 'bi bi-chevron-right'"
+        ></i>
+        @if (extended) {
+            <span  class="sidebar-font-btn">Cerrar</span>
+        }
     </button>
-    <img
-      [ngClass]="extended ? 'side-img-extended' : 'side-img'"
-      src="assets/images/logo.svg"
-      alt="logo" />
-  </div>
+    <div class="d-flex flex-column">
+        <img
+            [ngClass]="extended ? 'side-img-extended' : 'side-img'"
+            src="assets/images/logo.svg"
+            alt="logo"
+        />
+    </div>
 
   <!-- Botones cargados desde el componente dependiendo del rol del usuario -->
   <div class="sidebar-btns-container">
@@ -63,7 +74,7 @@
 
 
 
- 
+
 
 <div class="sidebar" [ngClass]="{'active': isSidebarOpen}">
   <div class="mb-5 side-img">
@@ -100,7 +111,7 @@
         <span class="sidebar-font-btn">Configuración</span>
       </button>
       <button
-      
+
             class="sidebar-btns text-white mt-3"
             (click)="logout()">
             <i class="bi bi-box-arrow-left"></i>


### PR DESCRIPTION
Cambio estetico al boton para colapsar y expandir sidebar.
Resolución issue #146.

Antes:
<img width="235" height="251" alt="image" src="https://github.com/user-attachments/assets/2fb54b4a-1ac6-44e9-932f-749f5738ba53" />

Después:
<img width="102" height="218" alt="image" src="https://github.com/user-attachments/assets/b8696a1f-84db-4f6d-9f6c-365eb8912237" />
<img width="235" height="251" alt="image" src="https://github.com/user-attachments/assets/83535aa6-65e9-4555-a4ff-a16d8b02dfce" />


