### PR TITLE
Hotfix/186 bugs editar quiz

### DIFF
--- a/src/app/modules/edit/pages/edit-pages/choise-question/choice-question.component.html
+++ b/src/app/modules/edit/pages/edit-pages/choise-question/choice-question.component.html
@@ -5,6 +5,7 @@
                 <span>
                   <div class="checkbox-container">
                     <input
+                        disabled
                         [type]="
                         question.type === 'multiple_choice'
                           ? 'checkbox'

--- a/src/app/modules/edit/pages/edit-pages/edit-pages.component.html
+++ b/src/app/modules/edit/pages/edit-pages/edit-pages.component.html
@@ -9,19 +9,19 @@
     </div>
 
     <div class="content-1">
-        <div [formGroup]="selectNameForm" class="quiz-info">
+        <div class="quiz-info">
             <div class="form-group">
                 <input
                     type="text"
-                    formControlName="name"
+                    [(ngModel)]="quiz.name"
                     class="custom-input"
                     placeholder="Nombre del quiz"
                     style="width: max-content" />
             </div>
             <div class="form-group">
                 <input
+                    [(ngModel)]="quiz.description"
                     type="text"
-                    formControlName="description"
                     class="custom-input"
                     placeholder="Descripción del quiz" />
             </div>
@@ -34,8 +34,8 @@
             (datosParaPadre)="receiveCategory($event)">
         </app-header-page>
 
-        <div [formGroup]="selectNameForm" id="questions-scroll">
-            <div formArrayName="questions" id="question-container">
+        <div id="questions-scroll">
+            <div id="question-container">
                 @for (question of this.questionsData; track $index){
                     <div class="question-container">
                         <app-question
@@ -50,12 +50,10 @@
                                 class="edit-popup content-2"
                             >
                                 <app-edit-question-pop-up
-                                    [currentEditingQuestion]="this.currentEditingQuestion"
-                                    [inputType]="this.currentEditingQuestion.type"
-                                    [selectedOption]="this.selectedOption"
+                                    [questionToEdit]="this.currentEditingQuestion"
                                     (cancel)="closeEditPopup()"
                                     (editedQuestion)="onEditHandler($event)"
-                                    [showPlus]="this.showPlus"
+
                                 />
                             </div>
                         }
@@ -65,7 +63,7 @@
                     class="actions-container"
                     style="display: flex; justify-content: space-around"
                 >
-                    <button (click)="createQuiz()" class="save-button">Guardar</button>
+                    <button (click)="saveQuiz()" class="save-button">Guardar</button>
                 </div>
             </div>
         </div>

--- a/src/app/modules/edit/pages/edit-pages/edit-pages.component.scss
+++ b/src/app/modules/edit/pages/edit-pages/edit-pages.component.scss
@@ -12,6 +12,7 @@ $border-color: rgba(241, 121, 197, 1);
   background-color: $background-dark;
   height: 95vh;
   padding: 20px;
+    width:70dvw;
   border-radius: 15px;
   margin-block: 2.5vh;
 }

--- a/src/app/modules/edit/pages/edit-pages/edit-pages.component.ts
+++ b/src/app/modules/edit/pages/edit-pages/edit-pages.component.ts
@@ -27,146 +27,111 @@ import {Quiz} from '../../../../shared/question-container/question-interface';
 })
 export class EditPagesComponent implements OnInit {
     private quizService = inject(QuizService);
-    private formBuilder = inject(FormBuilder);
     @Input() quizId: string;
     @Output() close = new EventEmitter<void>();
     quiz : Quiz={} as Quiz;
     questionsData: Question[] = [];
     currentEditingQuestion: null| Question = null;
     currentEditingIndex: number | null = null;
-    selectNameForm: FormGroup;
     showEditForm: boolean = false;
-    selectedOption: string = '';
-    options: string[] = [];
-    inputType: string = '';
-    showPlus: boolean = false;
-    showSubmits: boolean = false;
-    selectedValues: boolean[] = [];
-    correct_option: number[] = [];
+
+
     initialQuizCategory: any = null;
     cell_id: string = '';
     seniority: string = '';
 
-    constructor(
-    ) {
-        this.selectNameForm = this.formBuilder.group({
-      name: [''],
-      description: [''],
-      questions: this.formBuilder.array([]),
-    });
-  }
-
-  ngOnInit() {
-    if (this.quizId) {
-      this.loadQuiz();
-    }
-  }
-
-  private loadQuiz() {
-    if (!this.quizId) {
-      console.error('Quiz ID no proporcionado');
-      return;
+    ngOnInit() {
+        this.loadQuiz();
     }
 
-    this.quizService.getQuizWithQuestions(this.quizId).subscribe({
-      next: (quizData : Quiz) => {
-        this.selectNameForm.patchValue({
-          name: quizData.name,
-          description: quizData.description,
+    private loadQuiz() {
+        if (!this.quizId) {
+            console.error('Quiz ID no proporcionado');
+            return;
+        }
+
+        this.quizService.getQuizWithQuestions(this.quizId).subscribe({
+            next: (quizData : Quiz) => {
+                this.initialQuizCategory = {
+                    module: quizData.cell.module.name,
+                    module_id: quizData.cell.module.id,
+                    cell: quizData.cell.name,
+                    cell_id: quizData.cell.id,
+                    seniority: quizData.seniority
+                };
+
+                console.log('Modulo inicial:', this.initialQuizCategory);
+                this.quiz = quizData;
+                quizData.questions.forEach((data,index) => this.questionsData.push(this.ToQuestion(data,index)));
+            },
+            error: error => {
+                console.error('Error al obtener el cuestionario:', error);
+            },
         });
-
-        this.initialQuizCategory = {
-          module: quizData.cell.module.name,
-          module_id: quizData.cell.module.id,
-          cell: quizData.cell.name,
-          cell_id: quizData.cell.id,
-          seniority: quizData.seniority
-        };
-
-        console.log('Modulo inicial:', this.initialQuizCategory);
-        this.quiz = quizData;
-
-        quizData.questions.forEach((data,index) => this.questionsData.push(this.ToQuestion(data,index)));
-      },
-      error: error => {
-        console.error('Error al obtener el cuestionario:', error);
-      },
-    });
-  }
-
-
-
-
-
-  get questions(): FormArray {
-    return this.selectNameForm.get('questions') as FormArray;
-  }
-
-
-  receiveCategory(quizCategory: any) {
-    this.initialQuizCategory.module = quizCategory.module;
-    this.initialQuizCategory.module_id = quizCategory.moduleId;
-    this.cell_id = quizCategory.cellId;
-    this.seniority = quizCategory.seniority;
-    this.initialQuizCategory.cell_id = quizCategory.cellId;
-    this.initialQuizCategory.seniority = quizCategory.seniority;
-  }
-  createQuiz() {
-    this.quizService.updateQuiz(this.quizId, this.toUpdateQuizRequest()).subscribe({
-      next: response => {
-        console.log('Cambios guardados para el quiz:', response);
-        this.close.emit();
-      },
-      error: error => {
-        console.error('Error al guardar cambios:', error);
-      },
-    });
-  }
-
-  private ToQuestion(data: ResponseQuestion, questionNumber : number): Question {
-    return {
-      id: data.id,
-      correct_option: data.correct_option,
-      options: data.options,
-      question: data.question,
-      questionNumber: questionNumber,
-      type: data.type,
-      seniority: this.quiz.seniority,
     }
-  }
-  private toUpdateQuizRequest(): UpdateQuizRequest{
-    return {
-      cell_id: this.quiz.cell_id,
-      challenge_type: this.quiz.challenge_type,
-      created_by_id: this.quiz.created_by_id,
-      description: this.quiz.description,
-      is_active: this.quiz.is_active,
-      max_time: this.quiz.max_time,
-      name: this.quiz.name,
-      questions: this.questionsData,
-      seniority: this.quiz.seniority,
 
+    receiveCategory(quizCategory: any) {
+        this.initialQuizCategory.module = quizCategory.module;
+        this.initialQuizCategory.module_id = quizCategory.moduleId;
+        this.cell_id = quizCategory.cellId;
+        this.seniority = quizCategory.seniority;
+        this.initialQuizCategory.cell_id = quizCategory.cellId;
+        this.initialQuizCategory.seniority = quizCategory.seniority;
+        this.quiz.cell_id = quizCategory.cellId;
+        this.quiz.seniority = (quizCategory.seniority ?? '').toString().toLowerCase();
     }
-  }
-  showEditPopup(questionIndex: number) {
-    this.currentEditingQuestion = this.questionsData[questionIndex];
-    this.currentEditingIndex = questionIndex;
-    this.showEditForm = true;
-    this.showSubmits = true;
-  }
 
-  closeEditPopup() {
-    this.showEditForm = false;
-    this.currentEditingQuestion = null;
-    this.currentEditingIndex = null;
-    this.options = [];
-    this.correct_option = [];
-    this.selectedValues = [];
-  }
+    private ToQuestion(data: ResponseQuestion, questionNumber : number): Question {
+        return {
+            id: data.id,
+            correct_option: data.correct_option,
+            options: data.options,
+            question: data.question,
+            questionNumber: questionNumber,
+            type: data.type,
+            seniority: this.quiz.seniority,
+        }
+    }
+    private toUpdateQuizRequest(): UpdateQuizRequest{
+        return {
+            cell_id: this.quiz.cell_id,
+            challenge_type: this.quiz.challenge_type,
+            created_by_id: this.quiz.created_by_id,
+            description: this.quiz.description,
+            is_active: this.quiz.is_active,
+            max_time: this.quiz.max_time,
+            name: this.quiz.name,
+            questions: this.questionsData,
+            seniority: this.quiz.seniority,
 
-  onEditHandler(question: Question) {
-    this.questionsData[question.questionNumber]= question;
-    this.closeEditPopup();
-  }
+        }
+    }
+    showEditPopup(questionIndex: number) {
+        this.currentEditingQuestion = this.questionsData[questionIndex];
+        this.currentEditingIndex = questionIndex;
+        this.showEditForm = true;
+    }
 
+    closeEditPopup() {
+        this.currentEditingQuestion = null;
+        this.currentEditingIndex = null;
+        this.showEditForm = false;
+    }
+
+    onEditHandler(question: Question) {
+        this.questionsData[question.questionNumber]= question;
+        this.closeEditPopup();
+    }
+
+    saveQuiz() {
+        this.quizService.updateQuiz(this.quizId, this.toUpdateQuizRequest()).subscribe({
+            next: response => {
+                console.log('Cambios guardados para el quiz:', response);
+                this.close.emit();
+            },
+            error: error => {
+                console.error('Error al guardar cambios:', error);
+            },
+        });
+    }
 }

--- a/src/app/modules/edit/pages/edit-pages/edit-question-pop-up/edit-question-pop-up.component.html
+++ b/src/app/modules/edit/pages/edit-pages/edit-question-pop-up/edit-question-pop-up.component.html
@@ -14,7 +14,7 @@
                         id="questionType"
                         name="questionType"
                         [(ngModel)]="this.currentEditingQuestion.type"
-                        (ngModelChange)="onQuestionTypeChange()"
+                        (ngModelChange)="changeQuestionType()"
                         required
                     >
                         @for (type of questionTypes; track $index){
@@ -53,7 +53,7 @@
                                         type="checkbox"
                                         class="checkbox-input"
                                         [checked]="this.currentEditingQuestion.correct_option.includes?.($index)"
-                                        (click)="answerChoice($index)"
+                                        (click)="changeQuestionAnswer($index)"
                                         [name]="'checkbox' + $index"
                                     />
                                 } @else if (this.currentEditingQuestion.type === 'true_false') {
@@ -62,7 +62,7 @@
                                         class="checkbox-input"
                                         [checked]="this.currentEditingQuestion.correct_option.includes($index)"
                                         name="radioGroup"
-                                        (click)="answerChoice($index)"
+                                        (click)="changeQuestionAnswer($index)"
                                     />
                                 }
                                </div>
@@ -71,7 +71,7 @@
                                  class="custom-option-input"
                                  type="text"
                                  [value]='this.currentEditingQuestion.options.at($index)'
-                                 (keyup)="changeText($event,$index)"
+                                 (keyup)="changeQuestionText($event,$index)"
                                  name="option{{ $index }}"
                                  [readonly]="isTrueFalseQuestion"
                                  [placeholder]="'Opción ' + ($index + 1)"
@@ -101,7 +101,7 @@
                 <button type="submit" class="custom-btn-submit" (click)="saveChanges()">
                     Guardar
                 </button>
-                <button class="close-button" (click)="closeEditPopup()">
+                <button class="close-button" (click)="this.cancel.emit()">
                     Cerrar
                 </button>
             </div>

--- a/src/app/modules/edit/pages/edit-pages/edit-question-pop-up/edit-question-pop-up.component.ts
+++ b/src/app/modules/edit/pages/edit-pages/edit-question-pop-up/edit-question-pop-up.component.ts
@@ -1,4 +1,11 @@
-import { Component, EventEmitter, Input,  Output } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  EventEmitter,
+  Input,
+  OnInit,
+  Output,
+} from '@angular/core';
 import {   FormsModule } from '@angular/forms';
 import { CommonModule   } from '@angular/common';
 import { Question } from '../../../../../shared/question-container/question-interface';
@@ -10,18 +17,16 @@ import { TypeOptionsPipe } from '../type-options.pipe';
   imports: [FormsModule, CommonModule, TypeOptionsPipe],
   templateUrl: './edit-question-pop-up.component.html',
   styleUrl: './edit-question-pop-up.component.scss',
-})
-export class EditQuestionPopUpComponent {
-  @Input() currentEditingQuestion: Question;
-  @Input() questionToEdit: Question;
-  @Input() inputType: string = '';
-  @Input() selectedOption: string = '';
-  isTrueFalseQuestion : boolean = true;
-  @Input() showPlus: boolean = false;
-  @Input() showInput: boolean = true;
 
+})
+export class EditQuestionPopUpComponent implements OnInit {
+  @Input() questionToEdit: Question;
+  @Input() showInput: boolean = true;
   @Output() editedQuestion = new EventEmitter<Question>();
   @Output() cancel = new EventEmitter<void>();
+  isTrueFalseQuestion : boolean = true;
+  currentEditingQuestion: Question;
+  showPlus: boolean = false;
   showSubmits: boolean = true;
   questionTypes: string[] = [
     'multiple_choice',
@@ -29,66 +34,80 @@ export class EditQuestionPopUpComponent {
     'true_false',
   ];
 
+  ngOnInit() {
+    this.currentEditingQuestion = structuredClone(this.questionToEdit);
+    this.isTrueFalseQuestion = this.isTrueFalseQuestionMethod();
+    this.showPlus = !this.isTrueFalseQuestionMethod();
+  }
   saveChanges() {
     this.deleteEmptyOptions();
     this.editedQuestion.emit(this.currentEditingQuestion);
   }
-  private deleteEmptyOptions() {
-    this.currentEditingQuestion.options = this.currentEditingQuestion.options.filter(option => option.trim() !== '');
-  }
 
-  closeEditPopup() {
-    this.cancel.emit();
-  }
   addOption() {
     this.currentEditingQuestion.options.push('Opción nueva');
   }
+  changeQuestionAnswer(index: number) {
+    if (this.isTrueFalseQuestionMethod()) {
+      this.currentEditingQuestion.correct_option = [index];
+    } else {
+      const idx = this.currentEditingQuestion.correct_option.indexOf(index);
+      if (idx > -1) {
+        this.currentEditingQuestion.correct_option.splice(idx, 1);
+      } else {
+        this.currentEditingQuestion.correct_option.push(index);
+      }
+    }
+  }
 
- answerChoice(index: number) {
-   if (this.currentEditingQuestion.type === 'true_false') {
-     this.currentEditingQuestion.correct_option = [index];
-   } else {
-     const idx = this.currentEditingQuestion.correct_option.indexOf(index);
-     if (idx > -1) {
-       this.currentEditingQuestion.correct_option.splice(idx, 1);
-     } else {
-       this.currentEditingQuestion.correct_option.push(index);
-     }
-   }
- }
-  changeText($event, index) {
+  changeQuestionText($event, index) {
     this.currentEditingQuestion.options[index] = $event.target.value;
   }
 
-  onQuestionTypeChange() {
+  changeQuestionType() {
     this.currentEditingQuestion.correct_option = [];
     this.currentEditingQuestion.correct_option.push(0);
     this.currentEditingQuestion.options = [];
     this.showSubmits = true;
     const selectedType = this.currentEditingQuestion.type;
     if (selectedType === 'true_false') {
-      this.currentEditingQuestion.options = ['Verdadero', 'Falso'];
-      this.inputType = 'radio';
-      this.isTrueFalseQuestion = true;
-      this.showPlus = false;
+      this.setTypeToTrueFalse();
     } else if (selectedType === 'multiple_choice') {
-      this.currentEditingQuestion.options = [
-        'Opción 1',
-        'Opción 2',
-        'Opción 3',
-      ];
-      this.inputType = 'checkbox';
-      this.isTrueFalseQuestion = false;
-      this.showPlus = true;
-      this.currentEditingQuestion.correct_option.push(1);
+     this.setTypeToMultipleChoice();
     } else if (selectedType === 'simple_choice') {
-      this.currentEditingQuestion.options = ['Opción 1', 'Opción 2'];
-      this.inputType = 'radio';
-      this.isTrueFalseQuestion = false;
-      this.showPlus = true;
-    } else {
-      this.showPlus = false;
+     this.setTypeToSimpleChoice();
     }
+  }
+
+  private setTypeToTrueFalse() {
+    this.currentEditingQuestion.options = ['Verdadero', 'Falso'];
+    this.isTrueFalseQuestion = true;
+    this.showPlus = false;
+  }
+
+  private setTypeToMultipleChoice() {
+    this.currentEditingQuestion.options = [
+      'Opción 1',
+      'Opción 2',
+      'Opción 3',
+    ];
+    this.isTrueFalseQuestion = false;
+    this.showPlus = true;
+    this.currentEditingQuestion.correct_option.push(1);
+  }
+
+  private setTypeToSimpleChoice() {
+    this.currentEditingQuestion.options = ['Opción 1', 'Opción 2'];
+    this.isTrueFalseQuestion = false;
+    this.showPlus = true;
+  }
+
+  private deleteEmptyOptions() {
+    this.currentEditingQuestion.options = this.currentEditingQuestion.options.filter(option => option.trim() !== '');
+  }
+
+  private isTrueFalseQuestionMethod(): boolean{
+    return !this.currentEditingQuestion.type.includes('choice');
   }
 }
 

--- a/src/app/modules/edit/pages/edit-pages/true-false-question/true-false-question.component.html
+++ b/src/app/modules/edit/pages/edit-pages/true-false-question/true-false-question.component.html
@@ -3,11 +3,12 @@
       <span>
         <div class="checkbox-container">
           <input
+              disabled
               type="radio"
               class="checkbox-input"
               name="correct_option_{{ index }}"
               [checked]="question.correct_option[0]=== 0"
-              (change)="selectCorrectOption(index, 'Falso')" />
+          />
         </div>
 
         <label class="option-label">Falso</label>
@@ -17,11 +18,12 @@
           <span>
             <div class="checkbox-container">
               <input
+                 disabled
                   type="radio"
                   class="checkbox-input"
                   name="correct_option_{{ index }}"
                   [checked]="question.correct_option[0]=== 1"
-                  (change)="selectCorrectOption(index, 'Verdadero')" />
+              />
             </div>
 
             <label class="option-label">Verdadero</label>

--- a/src/app/modules/edit/pages/edit-pages/true-false-question/true-false-question.component.ts
+++ b/src/app/modules/edit/pages/edit-pages/true-false-question/true-false-question.component.ts
@@ -15,13 +15,5 @@ import {
 export class TrueFalseQuestionComponent {
   @Input() question : Question;
   @Input() index : any;
-  selectCorrectOption(questionIndex: number, optionValue: string) {
-    /*const question = this.questions.at(questionIndex);
-    if (question.get('type')?.value === 'true_false') {
-      const correctOption = optionValue === 'Verdadero' ? 0 : 1;
-      question.patchValue({
-        correct_option: correctOption,
-      });
-    }*/
-  }
+
 }


### PR DESCRIPTION
Resolución issue #186 
FEATS:
1. Editar información asociada a un quiz: nombre, descripción, célula y seniority.
2. Refactor: renombramiento de metodos para mejor lectura del código, eliminación de atributos que no cumplian ninguna función real.

BUGS RESUELTOS:
1. Aislamiento al editar una pregunta, en vez de clonar la pregunta al editPopupComponent usaba la referencia a la pregunta del componente padre, ocasionando errores inesperados.
3. Solución parcial: agrande en css el tamaño del contenedor del formulario de editar quiz.
4. Hice disabled los inputs de las preguntas para que se obligue al usuario a usar el EditPopupComponent.
