### PR TITLE
Feature: limitar a 6 opciones por pregunta de seleccion.

### DIFF
--- a/src/app/modules/edit/pages/edit-pages/edit-question-pop-up/edit-question-pop-up.component.ts
+++ b/src/app/modules/edit/pages/edit-pages/edit-question-pop-up/edit-question-pop-up.component.ts
@@ -41,8 +41,13 @@ export class EditQuestionPopUpComponent {
     this.cancel.emit();
   }
   addOption() {
-    this.currentEditingQuestion.options.push('Opción nueva');
+    if(this.currentEditingQuestion.options.length < 6){
+      this.currentEditingQuestion.options.push('Opción nueva');
+    }else{
+      alert('El límite son 6 opciones.');
+    }
   }
+
 
  answerChoice(index: number) {
    if (this.currentEditingQuestion.type === 'true_false') {
@@ -91,4 +96,5 @@ export class EditQuestionPopUpComponent {
     }
   }
 }
+
 


### PR DESCRIPTION
Resolución #190 
En vez de 5, opté por 6 ya que al crear un nuevo quiz éste es el límite.