### PR TITLE
fix: acomodando lectura de rol y redirección del admin con credencial…

### DIFF
--- a/src/app/modules/auth/local-auth.service.ts
+++ b/src/app/modules/auth/local-auth.service.ts
@@ -8,27 +8,40 @@ export class LocalAuthService {
 
   private userStateService = inject(UserStateService);
 
+  // Custom Claim para roles que espera el RoleGuard y el UserStateService
+  private readonly ROLES_CLAIM = 'https://miaplicacion.com/roles';
+  // Asume que el claim de rol en tu JWT local se llama 'role'
+  private readonly LOCAL_ROLE_PROPERTY = 'role';
+
   setToken(token: string) {
     localStorage.setItem(this.tokenKey, token);
 
     try {
       const decodedUser: any = jwtDecode(token);
-      
+
+      // 1. Obtener el rol del token JWT local (asumiendo que se llama 'role')
+      const localRole = decodedUser[this.LOCAL_ROLE_PROPERTY] || 'candidato';
+
+      // Asegurar que el rol sea un array de strings para compatibilidad con Auth0 y RoleGuard
+      const rolesArray = Array.isArray(localRole) ? localRole : [localRole];
+
       // Se mapea el payload del JWT a las propiedades esperadas por el dashboard
       const userData = {
-        name: decodedUser.first_name || decodedUser.email, 
+        name: decodedUser.first_name || decodedUser.email,
         email: decodedUser.email,
         sub: decodedUser.sub,
         // Se incluye cualquier otra propiedad necesaria (ej: picture, role)
-        picture: decodedUser.picture, 
+        picture: decodedUser.picture,
+
+        // 2. ¡EL CAMBIO CLAVE! Incluir el claim de rol con el nombre COMPLETO que espera el RoleGuard
+        [this.ROLES_CLAIM]: rolesArray, // Esto se convierte en 'https://miaplicacion.com/roles': ['admin']
       };
 
       this.userStateService.setLocalUser(userData);
-
     } catch (e) {
       console.error('Error al decodificar o establecer el usuario local:', e);
       // Opcional: limpiar token si la decodificación falla
-      this.clearToken(); 
+      this.clearToken();
     }
   }
 
@@ -38,11 +51,12 @@ export class LocalAuthService {
 
   clearToken() {
     localStorage.removeItem(this.tokenKey);
-     // Notificar al UserStateService sobre el logout
+    // Notificar al UserStateService sobre el logout
     this.userStateService.clearLocalUser();
   }
 
-  getUser(): any{ // Por ahora debe ser any, hasta que se adapte el login (falta el rol del usuario en la estrategia jwt)
+  getUser(): any {
+    // Por ahora debe ser any, hasta que se adapte el login (falta el rol del usuario en la estrategia jwt)
     const token = this.getToken();
     return token ? jwtDecode(token) : null;
   }

--- a/src/app/modules/auth/pages/login/login.component.ts
+++ b/src/app/modules/auth/pages/login/login.component.ts
@@ -71,7 +71,7 @@ export class LoginComponent implements OnInit {
       )
       .subscribe(user => {
         // Redirección directa. El Guard hace la validación de rol.
-        this.router.navigate(['/dashboard']);
+        this.router.navigate(['/home']);
       });
     this.loginForm = this.fb.group({
       email: ['', [Validators.required, Validators.email]],
@@ -104,7 +104,7 @@ export class LoginComponent implements OnInit {
             this.alertService.showSuccess('Inicio de sesión exitoso');
 
             // 2. Redirección directa. El RoleGuard en /dashboard validará el rol.
-            this.router.navigate(['/dashboard']);
+            this.router.navigate(['/home']);
           },
           error: error => {
             console.error('🔒 Error al iniciar sesión:', error);


### PR DESCRIPTION
…es a home.

Tarea #237 

1. Ahora la decodificación del rol del usuario logueado por credenciales se realiza correctamente.
2. La redirección inicial para todos los usuarios será a /home para que se active el role.guard y cause la redirección según corresponda.

Nota: Para la siguiente edición quedará pendiente bloquear el /dashboard para los admin